### PR TITLE
Remove unused unstable feature custom_attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(custom_attribute)]
-
 use std::borrow::Cow;
 
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
This seems to have been added by @kigawas in #2, but it is not used -- and it prohibits the crate from being used on stable Rust.