### PR TITLE
Bump version to 0.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paillier"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
Actually, the version bumped to in #5 was already tagged 19 days ago (but apparently not updated in the crate metadata). Bump the version in the crate metadata once more to 0.3.2.

(After that, can you add a tag, too?)